### PR TITLE
fix: use decoded segment size for upload offset calculation

### DIFF
--- a/internal/repairnzb/repair_nzb.go
+++ b/internal/repairnzb/repair_nzb.go
@@ -251,6 +251,10 @@ func replaceBrokenSegments(
 		}
 
 		fileSize := fs.Size()
+		totalSegments := int64(nzbFile.TotalSegments)
+		// s.segment.Bytes is the yEnc-encoded article size (~10% larger than decoded binary).
+		// The repaired file contains decoded binary data, so compute offsets from actual file size.
+		decodedSegSize := (fileSize + totalSegments - 1) / totalSegments
 
 		p := pool.New().WithContext(ctx).
 			WithMaxGoroutines(cfg.UploadWorkers).
@@ -264,16 +268,23 @@ func replaceBrokenSegments(
 					return nil
 				}
 
-				// Get the segment from the file
-				buff := make([]byte, s.segment.Bytes)
-				_, err := tmpFile.ReadAt(buff, int64((s.segment.Number-1)*s.segment.Bytes))
+				// Get the segment from the file using decoded segment boundaries.
+				segNum := int64(s.segment.Number)
+				readOffset := (segNum - 1) * decodedSegSize
+				readSize := decodedSegSize
+				if segNum >= totalSegments {
+					readSize = fileSize - readOffset
+				}
+
+				buff := make([]byte, readSize)
+				_, err := tmpFile.ReadAt(buff, readOffset)
 				if err != nil {
 					slog.With("err", err).ErrorContext(ctx, "failed to read segment")
 
 					return err
 				}
 
-				partSize := int64(s.segment.Bytes)
+				partSize := readSize
 				date := time.UnixMilli(int64(nzbFile.Date))
 
 				subject := fmt.Sprintf("[%v/%v] %v - \"\" yEnc (%v/%v)", s.file.Number, nzb.TotalFiles, s.file.Filename, int64(s.segment.Number), s.file.TotalSegments)


### PR DESCRIPTION
## Summary

- Fixes the `err=EOF` failure when uploading repaired segments after PAR2 repair (fixes #8)
- `s.segment.Bytes` in NZB metadata is the **yEnc-encoded** article size, which is ~10% larger than the decoded binary data that the repaired file actually contains
- Both the `ReadAt` offset and buffer size were computed using the encoded size, causing reads to run past the end of the actual file

## What changed

In `replaceBrokenSegments` ([`internal/repairnzb/repair_nzb.go`](internal/repairnzb/repair_nzb.go)):

- Compute `decodedSegSize = ceil(fileSize / totalSegments)` from the actual repaired file size reported by `os.Stat`
- Use this for both the `ReadAt` offset (`(segNum - 1) * decodedSegSize`) and the read buffer size
- The last segment reads `fileSize - readOffset` bytes to handle the smaller trailing segment correctly
- Pass the actual `readSize` as `partSize` to `rapidyenc.Meta` instead of the encoded NZB bytes

## Why this works

The download worker writes decoded binary data at offsets `(s.Number - 1) * decodedSize`. PAR2 repairs the file in-place at those same binary positions. The upload code must read using the same decoded-size-based offsets — not the larger yEnc-encoded sizes from the NZB.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all existing tests green)
- Manual verification requires an NZB with missing articles that triggers PAR2 repair + re-upload