### PR TITLE
fix: resolve par2 relative path to absolute before setting cmd.Dir

### DIFF
--- a/internal/repairnzb/par2.go
+++ b/internal/repairnzb/par2.go
@@ -78,8 +78,15 @@ func (p *Par2CmdExecutor) Repair(ctx context.Context, tmpPath string) error {
 
 	par2Exe := p.ExePath
 	if par2Exe == "" {
-		par2Exe = "par2" // Default if path is empty
+		par2Exe = "par2"
 		slog.WarnContext(ctx, "Par2 executable path is empty, defaulting to 'par2'")
+	}
+	// Resolve relative file paths (./foo, ../foo, foo/bar) to absolute so they survive
+	// cmd.Dir being changed to tmpPath. Bare names like "par2" are left alone for PATH lookup.
+	if strings.ContainsRune(par2Exe, os.PathSeparator) || strings.HasPrefix(par2Exe, ".") {
+		if absPath, err := filepath.Abs(par2Exe); err == nil {
+			par2Exe = absPath
+		}
 	}
 
 	exp, _ := regexp.Compile(`^.+\.par2`)

--- a/internal/repairnzb/par2_test.go
+++ b/internal/repairnzb/par2_test.go
@@ -207,6 +207,32 @@ Done.`)
 		assert.NoError(t, err)
 	})
 
+	t.Run("Relative ExePath is resolved to absolute before exec", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		par2File := filepath.Join(tmpDir, "test.par2")
+		f, err := os.Create(par2File)
+		require.NoError(t, err)
+		_ = f.Close()
+
+		var capturedPath string
+		execCommand = func(ctx context.Context, command string, args ...string) *exec.Cmd {
+			capturedPath = command
+			cs := []string{"-test.run=TestHelperProcess", "--", "echo"}
+			cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+			cmd.Env = append(os.Environ(), "GO_TEST_HELPER_PROCESS=1",
+				"TEST_PAR2_EXIT_CODE=0", "TEST_PAR2_STDOUT=", "TEST_PAR2_STDERR=")
+			return cmd
+		}
+		defer func() { execCommand = originalExecCommand }()
+
+		executor := &Par2CmdExecutor{ExePath: "./par2cmd"}
+		_ = executor.Repair(context.Background(), tmpDir)
+
+		if !filepath.IsAbs(capturedPath) {
+			t.Errorf("expected absolute path to be passed to execCommand, got %q", capturedPath)
+		}
+	})
+
 	t.Run("Empty ExePath uses default", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		par2File := filepath.Join(tmpDir, "test.par2")


### PR DESCRIPTION
## Summary

- Fixes `fork/exec ./par2cmd: no such file or directory` reported in #9
- Root cause: `cmd.Dir = tmpPath` changes the working directory before exec, so a relative `ExePath` like `./par2cmd` was resolved against the tmp folder instead of the original working directory
- Fix: paths containing a separator or starting with `.` are resolved to absolute with `filepath.Abs()` before the command is built; bare names like `par2` are left as-is for PATH lookup

## Test Plan

- [ ] Added `TestPar2CmdExecutor_Repair/Relative_ExePath_is_resolved_to_absolute_before_exec` — verifies the path passed to `execCommand` is absolute when `ExePath` is a relative path
- [ ] All existing tests continue to pass (`go test -race ./...`)
- [ ] Manually: place `par2cmd` in the nzb-repair root, run with `--par2-exe ./par2cmd`, repair should succeed