### PR TITLE
Fix par2cmd autodownload for zip releases

### DIFF
--- a/pkg/par2exedownloader/par2exe_downloader_test.go
+++ b/pkg/par2exedownloader/par2exe_downloader_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -54,7 +55,7 @@ func TestInstallPar2CmdFromZipExtractsPar2AsPar2Cmd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat(%q) error = %v", targetPath, err)
 	}
-	if info.Mode().Perm() != 0o755 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o755 {
 		t.Fatalf("installed file mode = %v, want 0755", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Summary
- Update par2cmdline-turbo asset matching for current zip-based release names, including macOS arm64.
- Extract the bundled par2 binary into the expected local executable path with safer temp-file handling.
- Add downloader tests for macOS arm64 asset selection and zip extraction behavior.

## Test plan
- go test ./pkg/par2exedownloader
- go test ./...