### PR TITLE
fix: use RFC1123Z for Date and bump nntppool to v4.10.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ tool (
 
 require (
 	github.com/Tensai75/nzbparser v0.1.0
-	github.com/javi11/nntppool/v4 v4.10.0
+	github.com/javi11/nntppool/v4 v4.10.1
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/mattn/go-sqlite3 v1.14.27
 	github.com/mnightingale/rapidyenc v0.0.0-20251128204712-7aafef1eaf1c

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/javi11/nntppool/v4 v4.10.0 h1:ZfrppG7CSht6PXIPCZT7iVtWuL/UrpF9zWQ5Lerk44E=
-github.com/javi11/nntppool/v4 v4.10.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
+github.com/javi11/nntppool/v4 v4.10.1 h1:NHoRniTnCRgpt/niljsWjA3gP5pYtNwxaqbLdr0Bcew=
+github.com/javi11/nntppool/v4 v4.10.1/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/jgautheron/goconst v1.8.2 h1:y0XF7X8CikZ93fSNT6WBTb/NElBu9IjaY7CCYQrCMX4=
 github.com/jgautheron/goconst v1.8.2/go.mod h1:A0oxgBCHy55NQn6sYpO7UdnA9p+h7cPtoOZUmvNIako=
 github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjzq7gFzUs=

--- a/internal/repairnzb/repair_nzb.go
+++ b/internal/repairnzb/repair_nzb.go
@@ -472,7 +472,7 @@ func replaceBrokenSegments(
 					Newsgroups: nzbFile.Groups,
 					MessageID: fmt.Sprintf("<%s>", msgId),
 					Extra: map[string][]string{
-						"Date": {date.UTC().Format(time.RFC1123)},
+						"Date": {date.UTC().Format(time.RFC1123Z)},
 					},
 				}
 


### PR DESCRIPTION
## Summary

Two coordinated fixes for articles being rejected by strict Usenet
backends (Astraweb / several Highwinds resellers respond 441):

1. **Date format** — `time.RFC1123` formats UTC as `"... UTC"`, but RFC 5322
   §3.3 requires a numeric zone offset. Switch to `time.RFC1123Z` so the
   header is emitted as `... +0000`.
2. **nntppool v4.10.0 → v4.10.1** — picks up library-side defensive
   validation (required fields, newsgroup syntax, Message-ID shape, CR/LF
   injection guard), RFC 5322 line folding for long Subject lines, RFC 2047
   B-encoding for non-ASCII Subject/From, and the body-terminator wire-fix
   (was emitting a stray blank line before `.\r\n`).

The repaired-file POST path in `repairnzb` is the only site setting the
Date header explicitly; the par2 upload path leaves it to nntppool, which
now auto-emits a valid Date in the bumped version.

## Test plan

- [x] `make check` (generate + tidy + lint + race tests) — green
- [ ] Manual smoke test against a previously-rejecting provider