### PR TITLE
fix: correct Date header in PostYEnc for repaired segments

### DIFF
--- a/internal/repairnzb/repair_nzb.go
+++ b/internal/repairnzb/repair_nzb.go
@@ -451,7 +451,7 @@ func replaceBrokenSegments(
 				}
 
 				partSize := readSize
-				date := time.UnixMilli(int64(nzbFile.Date))
+				date := time.Unix(int64(nzbFile.Date), 0)
 
 				subject := fmt.Sprintf("[%v/%v] %v - \"\" yEnc (%v/%v)", s.file.Number, nzb.TotalFiles, s.file.Filename, int64(s.segment.Number), s.file.TotalSegments)
 
@@ -467,13 +467,11 @@ func replaceBrokenSegments(
 				msgId := generateRandomMessageID()
 
 				headers := nntppool.PostHeaders{
-					From:      nzbFile.Poster,
-					Subject:   subject,
+					From:       nzbFile.Poster,
+					Subject:    subject,
 					Newsgroups: nzbFile.Groups,
-					MessageID: fmt.Sprintf("<%s>", msgId),
-					Extra: map[string][]string{
-						"Date": {date.UTC().Format(time.RFC1123Z)},
-					},
+					MessageID:  fmt.Sprintf("<%s>", msgId),
+					Date:       date.UTC(),
 				}
 
 				meta := rapidyenc.Meta{


### PR DESCRIPTION
## Summary

- `nzbFile.Date` is a Unix timestamp in **seconds**, but `time.UnixMilli` was used, placing re-uploaded segments' dates in 1970 instead of the correct year (e.g. a Jan 2023 article appeared as Jan 21 **1970**).
- The formatted date string was put in `PostHeaders.Extra["Date"]` instead of the `PostHeaders.Date` (`time.Time`) field, leaving the struct's `Date` at its zero value (`0001-01-01T00:00:00Z`). The nntppool library serialises `PostHeaders.Date` directly into the `Date:` header and does not look at `Extra["Date"]`.

Both bugs affected only `replaceBrokenSegments`; `uploadPar2Files` correctly omits `Date` so nntppool fills it with `time.Now()`.

## Changes

- `time.UnixMilli(int64(nzbFile.Date))` → `time.Unix(int64(nzbFile.Date), 0)`
- Removed `Extra: map[string][]string{"Date": {...}}`, set `Date: date.UTC()` in `PostHeaders` directly

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go test ./internal/repairnzb/...` passes (verified)
- [ ] Manual verification: posted article's `Date:` header matches the original NZB file date (not 1970, not zero)