### PR TITLE
fix: retry segment downloads on transient NNTP errors (502)

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -12,6 +12,7 @@ download_providers:
     user_agent: nzb-repair/1.0
     quota_bytes: 0          # 0 = unlimited
     quota_period_hours: 0   # 0 = no rolling window
+    reconnect_delay_seconds: 30  # re-add a provider this long after a 502; 0 = default (30s), negative = disabled
 
 upload_providers:
   - host: upload.example.com
@@ -33,6 +34,12 @@ scan_interval: 5m
 
 # Maximum number of retries for a failed download
 max_retries: 3
+
+# Per-segment download retries on transient NNTP errors (e.g. 502 "too many connections").
+# The delay grows exponentially with jitter, capped at download_retry_max_delay.
+download_retries: 5            # 0 = default (5)
+download_retry_base_delay: 2s  # 0 = default (2s)
+download_retry_max_delay: 60s  # 0 = default (60s)
 
 # Folder to move broken files to
 broken_folder: broken

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -357,6 +357,7 @@ func toNNTPProvider(p config.ProviderConfig) nntppool.Provider {
 		UserAgent:         p.UserAgent,
 		QuotaBytes:        p.QuotaBytes,
 		QuotaPeriod:       time.Duration(p.QuotaPeriodHours) * time.Hour,
+		ReconnectDelay:    time.Duration(p.ReconnectDelaySeconds) * time.Second,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,10 @@ type ProviderConfig struct {
 	QuotaBytes int64 `yaml:"quota_bytes"`
 	// QuotaPeriodHours is the rolling window (in hours) after which the quota resets.
 	QuotaPeriodHours int `yaml:"quota_period_hours"`
+	// ReconnectDelaySeconds is how long (in seconds) to wait before re-adding a
+	// provider that was removed after a 502 "service unavailable" response.
+	// 0 defaults to 30s; use a negative value to disable auto-reconnect.
+	ReconnectDelaySeconds int `yaml:"reconnect_delay_seconds"`
 }
 
 type Config struct {
@@ -65,6 +69,14 @@ type Config struct {
 	Par2RecreateThreshold float64 `yaml:"par2_recreate_threshold"`
 	// Par2RecreateRedundancy is the recovery percentage used when creating a new par2 set.
 	Par2RecreateRedundancy int `yaml:"par2_recreate_redundancy"`
+	// DownloadRetries is the number of times a single segment download is retried
+	// on a transient error (e.g. 502 "too many connections") before giving up.
+	DownloadRetries int64 `yaml:"download_retries"`
+	// DownloadRetryBaseDelay is the initial backoff between download retries.
+	// The delay grows exponentially with jitter, capped at DownloadRetryMaxDelay.
+	DownloadRetryBaseDelay time.Duration `yaml:"download_retry_base_delay"`
+	// DownloadRetryMaxDelay caps the backoff between download retries.
+	DownloadRetryMaxDelay time.Duration `yaml:"download_retry_max_delay"`
 }
 
 type UploadConfig struct {
@@ -82,14 +94,18 @@ type Option func(*Config)
 
 var (
 	providerConfigDefault = ProviderConfig{
-		Connections: 10,
-		IdleTimeout: 2400 * time.Second,
+		Connections:           10,
+		IdleTimeout:           2400 * time.Second,
+		ReconnectDelaySeconds: 30,
 	}
-	downloadWorkersDefault = 10
-	uploadWorkersDefault   = 10
-	scanIntervalDefault    = 5 * time.Minute
-	maxRetriesDefault      = int64(3)
-	brokenFolderDefault    = "broken"
+	downloadWorkersDefault        = 10
+	uploadWorkersDefault          = 10
+	scanIntervalDefault           = 5 * time.Minute
+	maxRetriesDefault             = int64(3)
+	brokenFolderDefault           = "broken"
+	downloadRetriesDefault        = int64(5)
+	downloadRetryBaseDelayDefault = 2 * time.Second
+	downloadRetryMaxDelayDefault  = 60 * time.Second
 )
 
 func mergeWithDefault(config ...Config) Config {
@@ -104,6 +120,9 @@ func mergeWithDefault(config ...Config) Config {
 			MaxRetries:             maxRetriesDefault,
 			BrokenFolder:           brokenFolderDefault,
 			Par2RecreateRedundancy: 10,
+			DownloadRetries:        downloadRetriesDefault,
+			DownloadRetryBaseDelay: downloadRetryBaseDelayDefault,
+			DownloadRetryMaxDelay:  downloadRetryMaxDelayDefault,
 		}
 	}
 
@@ -117,6 +136,10 @@ func mergeWithDefault(config ...Config) Config {
 
 		if p.IdleTimeout == 0 {
 			p.IdleTimeout = providerConfigDefault.IdleTimeout
+		}
+
+		if p.ReconnectDelaySeconds == 0 {
+			p.ReconnectDelaySeconds = providerConfigDefault.ReconnectDelaySeconds
 		}
 
 		cfg.DownloadProviders[i] = p
@@ -135,6 +158,10 @@ func mergeWithDefault(config ...Config) Config {
 
 		if p.IdleTimeout == 0 {
 			p.IdleTimeout = providerConfigDefault.IdleTimeout
+		}
+
+		if p.ReconnectDelaySeconds == 0 {
+			p.ReconnectDelaySeconds = providerConfigDefault.ReconnectDelaySeconds
 		}
 
 		cfg.UploadProviders[i] = p
@@ -159,6 +186,18 @@ func mergeWithDefault(config ...Config) Config {
 
 	if cfg.Par2RecreateRedundancy == 0 {
 		cfg.Par2RecreateRedundancy = 10
+	}
+
+	if cfg.DownloadRetries == 0 {
+		cfg.DownloadRetries = downloadRetriesDefault
+	}
+
+	if cfg.DownloadRetryBaseDelay == 0 {
+		cfg.DownloadRetryBaseDelay = downloadRetryBaseDelayDefault
+	}
+
+	if cfg.DownloadRetryMaxDelay == 0 {
+		cfg.DownloadRetryMaxDelay = downloadRetryMaxDelayDefault
 	}
 
 	return cfg

--- a/internal/repairnzb/repair_nzb.go
+++ b/internal/repairnzb/repair_nzb.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	mrand "math/rand/v2"
 	"os"
 	"path/filepath"
 	"sync"
@@ -33,10 +34,77 @@ type NNTPPool interface {
 
 const defaultSegmentSize = 750_000 // bytes per uploaded segment for recreated par2 files
 
+// isRetryableDownloadErr reports whether a segment download error is transient
+// and worth retrying. Terminal cases are handled by the caller:
+//   - context.Canceled: the whole repair is being torn down.
+//   - ErrArticleNotFound: the segment is genuinely missing and routed for repair.
+//   - ErrQuotaExceeded: the provider quota won't recover within this run.
+//
+// Everything else (including the generic wrapped "all providers exhausted: ...
+// 502 too many connections" error, which is NOT the ErrServiceUnavailable
+// sentinel) is treated as transient.
+func isRetryableDownloadErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, nntppool.ErrArticleNotFound) {
+		return false
+	}
+	if errors.Is(err, nntppool.ErrQuotaExceeded) {
+		return false
+	}
+	return true
+}
+
+// backoffDelay returns an exponential backoff with full jitter for the given
+// attempt, capped at max. The result is in the range [capped/2, capped] where
+// capped = min(base*2^attempt, max).
+func backoffDelay(attempt int, base, max time.Duration) time.Duration {
+	capped := base << attempt // base * 2^attempt
+	if capped <= 0 || capped > max {
+		// Guard against shift overflow and cap at max.
+		capped = max
+	}
+	half := capped / 2
+	return half + time.Duration(mrand.Int64N(int64(half)+1)) // [half, capped]
+}
+
+// retryDownload runs op, retrying transient failures with backoff. Non-retryable
+// errors are returned immediately for the caller to classify. After cfg.DownloadRetries
+// failed retries the last error is returned. ctx cancellation aborts the wait.
+func retryDownload(ctx context.Context, cfg config.Config, label string, op func() error) error {
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableDownloadErr(err) {
+			return err
+		}
+		lastErr = err
+		if int64(attempt) >= cfg.DownloadRetries {
+			return lastErr
+		}
+		delay := backoffDelay(attempt, cfg.DownloadRetryBaseDelay, cfg.DownloadRetryMaxDelay)
+		slog.WarnContext(ctx, fmt.Sprintf("transient error downloading %s, retry %d/%d in %s: %v",
+			label, attempt+1, cfg.DownloadRetries, delay, err))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
 // countMissingParSegments checks par2 segments without writing to disk.
 // Returns (missing, total, error).
 func countMissingParSegments(
 	ctx context.Context,
+	cfg config.Config,
 	downloadPool NNTPPool,
 	parFiles []nzbparser.NzbFile,
 ) (missing, total int64, err error) {
@@ -46,7 +114,10 @@ func countMissingParSegments(
 			if ctx.Err() != nil {
 				return missing, total, ctx.Err()
 			}
-			_, segErr := downloadPool.BodyStream(ctx, s.Id, io.Discard)
+			segErr := retryDownload(ctx, cfg, s.Id, func() error {
+				_, e := downloadPool.BodyStream(ctx, s.Id, io.Discard)
+				return e
+			})
 			if segErr != nil {
 				if errors.Is(segErr, nntppool.ErrArticleNotFound) {
 					missing++
@@ -266,7 +337,7 @@ func RepairNzb(
 	// Check par2 threshold (if configured)
 	needsParRecreation := false
 	if cfg.Par2RecreateThreshold > 0 && len(parFiles) > 0 {
-		missing, total, countErr := countMissingParSegments(ctx, downloadPool, parFiles)
+		missing, total, countErr := countMissingParSegments(ctx, cfg, downloadPool, parFiles)
 		if countErr != nil {
 			slog.With("err", countErr).WarnContext(ctx, "failed to count missing par2 segments, skipping threshold check")
 		} else if total > 0 {
@@ -583,7 +654,12 @@ func downloadWorker(
 		default:
 			p.Go(func(c context.Context) error {
 				buff := bytes.NewBuffer(make([]byte, 0))
-				if _, err := downloadPool.BodyStream(c, s.Id, buff); err != nil {
+				err := retryDownload(c, config, s.Id, func() error {
+					buff.Reset() // discard partial writes from a failed attempt
+					_, e := downloadPool.BodyStream(c, s.Id, buff)
+					return e
+				})
+				if err != nil {
 					if errors.Is(err, nntppool.ErrArticleNotFound) {
 						if brokenSegmentCh != nil {
 							slog.DebugContext(ctx, fmt.Sprintf("segment %s not found, sending for repair: %v", s.Id, err))

--- a/internal/repairnzb/retry_test.go
+++ b/internal/repairnzb/retry_test.go
@@ -1,0 +1,251 @@
+package repairnzb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Tensai75/nzbparser"
+	nntppool "github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzb-repair/internal/config"
+	"github.com/javi11/nzb-repair/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// errTransient mimics the wrapped "all providers exhausted" 502 error that is
+// NOT the ErrServiceUnavailable sentinel.
+var errTransient = errors.New("nntp: all providers exhausted: host: nntp auth: unexpected response to AUTHINFO PASS: 502 Too many connections")
+
+func TestIsRetryableDownloadErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"canceled", context.Canceled, false},
+		{"article not found", nntppool.ErrArticleNotFound, false},
+		{"quota exceeded", nntppool.ErrQuotaExceeded, false},
+		{"generic 502 too many connections", errTransient, true},
+		{"service unavailable sentinel", nntppool.ErrServiceUnavailable, true},
+		{"wrapped canceled", errors.New("boom: " + context.Canceled.Error()), true}, // not wrapped via %w
+		{"unknown", errors.New("some other error"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetryableDownloadErr(tt.err))
+		})
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	base := 2 * time.Second
+	maxDelay := 60 * time.Second
+
+	for attempt := range 64 {
+		d := backoffDelay(attempt, base, maxDelay)
+		require.GreaterOrEqual(t, d, time.Duration(0), "delay must be non-negative")
+		require.LessOrEqual(t, d, maxDelay, "delay must never exceed max (attempt %d)", attempt)
+	}
+
+	// Full-jitter lower bound: attempt 0 -> capped=base, delay in [base/2, base].
+	got := backoffDelay(0, base, maxDelay)
+	assert.GreaterOrEqual(t, got, base/2)
+	assert.LessOrEqual(t, got, base)
+}
+
+func TestRetryDownload_TransientThenSuccess(t *testing.T) {
+	cfg := fastRetryConfig()
+	calls := 0
+	err := retryDownload(context.Background(), cfg, "seg@test", func() error {
+		calls++
+		if calls < 3 {
+			return errTransient
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryDownload_Exhaustion(t *testing.T) {
+	cfg := fastRetryConfig()
+	cfg.DownloadRetries = 2
+	calls := 0
+	err := retryDownload(context.Background(), cfg, "seg@test", func() error {
+		calls++
+		return errTransient
+	})
+	require.ErrorIs(t, err, errTransient)
+	// 1 initial attempt + DownloadRetries retries.
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryDownload_NonRetryableReturnsImmediately(t *testing.T) {
+	cfg := fastRetryConfig()
+	calls := 0
+	err := retryDownload(context.Background(), cfg, "seg@test", func() error {
+		calls++
+		return nntppool.ErrArticleNotFound
+	})
+	require.ErrorIs(t, err, nntppool.ErrArticleNotFound)
+	assert.Equal(t, 1, calls, "non-retryable errors must not retry")
+}
+
+func TestRetryDownload_CancelDuringBackoff(t *testing.T) {
+	cfg := fastRetryConfig()
+	cfg.DownloadRetryBaseDelay = time.Hour // force a long wait so cancel wins
+	cfg.DownloadRetryMaxDelay = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := retryDownload(ctx, cfg, "seg@test", func() error {
+		return errTransient
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), time.Second, "must return promptly on cancel, not wait the full backoff")
+}
+
+func TestDownloadWorker_RetriesTransientThenSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := fastRetryConfig()
+	cfg.DownloadWorkers = 1
+
+	mockPool := mocks.NewMockNNTPPool(ctrl)
+	tmpDir := t.TempDir()
+
+	segID := "seg1@test"
+	content := []byte("segment payload")
+	file := nzbparser.NzbFile{
+		Filename:      "movie.bin",
+		Bytes:         int64(len(content)),
+		TotalSegments: 1,
+		Segments:      []nzbparser.NzbSegment{{Id: segID, Number: 1, Bytes: len(content)}},
+	}
+
+	gomock.InOrder(
+		mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).Return(nil, errTransient),
+		mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).Return(nil, errTransient),
+		mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, w io.Writer, _ ...func(nntppool.YEncMeta)) (*nntppool.ArticleBody, error) {
+				_, _ = w.Write(content)
+				return &nntppool.ArticleBody{}, nil
+			}),
+	)
+
+	brokenCh := make(chan brokenSegment, 1)
+	err := downloadWorker(context.Background(), cfg, mockPool, file, brokenCh, tmpDir)
+	require.NoError(t, err)
+	assert.Len(t, brokenCh, 0, "successful download must not queue a broken segment")
+
+	written, err := os.ReadFile(filepath.Join(tmpDir, file.Filename))
+	require.NoError(t, err)
+	assert.Equal(t, content, written)
+}
+
+func TestDownloadWorker_RetryExhaustionReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := fastRetryConfig()
+	cfg.DownloadWorkers = 1
+	cfg.DownloadRetries = 2
+
+	mockPool := mocks.NewMockNNTPPool(ctrl)
+	tmpDir := t.TempDir()
+
+	segID := "seg1@test"
+	file := nzbparser.NzbFile{
+		Filename:      "movie.bin",
+		Bytes:         10,
+		TotalSegments: 1,
+		Segments:      []nzbparser.NzbSegment{{Id: segID, Number: 1, Bytes: 10}},
+	}
+
+	// 1 initial + 2 retries = 3 attempts, all failing.
+	mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).
+		Return(nil, errTransient).Times(3)
+
+	err := downloadWorker(context.Background(), cfg, mockPool, file, nil, tmpDir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errTransient)
+}
+
+func TestDownloadWorker_ArticleNotFoundNoRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := fastRetryConfig()
+	cfg.DownloadWorkers = 1
+
+	mockPool := mocks.NewMockNNTPPool(ctrl)
+	tmpDir := t.TempDir()
+
+	segID := "missing@test"
+	file := nzbparser.NzbFile{
+		Filename:      "movie.bin",
+		Bytes:         10,
+		TotalSegments: 1,
+		Segments:      []nzbparser.NzbSegment{{Id: segID, Number: 1, Bytes: 10}},
+	}
+
+	// Must be called exactly once — no retries for a genuinely missing article.
+	mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).
+		Return(nil, nntppool.ErrArticleNotFound).Times(1)
+
+	brokenCh := make(chan brokenSegment, 1)
+	err := downloadWorker(context.Background(), cfg, mockPool, file, brokenCh, tmpDir)
+	require.NoError(t, err)
+	require.Len(t, brokenCh, 1, "missing segment must be routed for repair")
+	bs := <-brokenCh
+	assert.Equal(t, segID, bs.segment.Id)
+}
+
+func TestDownloadWorker_QuotaExceededNoRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := fastRetryConfig()
+	cfg.DownloadWorkers = 1
+
+	mockPool := mocks.NewMockNNTPPool(ctrl)
+	tmpDir := t.TempDir()
+
+	segID := "seg1@test"
+	file := nzbparser.NzbFile{
+		Filename:      "movie.bin",
+		Bytes:         10,
+		TotalSegments: 1,
+		Segments:      []nzbparser.NzbSegment{{Id: segID, Number: 1, Bytes: 10}},
+	}
+
+	// Quota won't recover this run — no retries, terminal error.
+	mockPool.EXPECT().BodyStream(gomock.Any(), segID, gomock.Any()).
+		Return(nil, nntppool.ErrQuotaExceeded).Times(1)
+
+	err := downloadWorker(context.Background(), cfg, mockPool, file, nil, tmpDir)
+	require.Error(t, err)
+}
+
+// fastRetryConfig returns a config with near-instant backoff so retry tests run fast.
+func fastRetryConfig() config.Config {
+	return config.Config{
+		DownloadWorkers:        1,
+		DownloadRetries:        5,
+		DownloadRetryBaseDelay: time.Microsecond,
+		DownloadRetryMaxDelay:  time.Millisecond,
+	}
+}


### PR DESCRIPTION
## Problem

A transient NNTP error — most visibly:

```
nntp: all providers exhausted: <host>: nntp auth: unexpected response to AUTHINFO PASS: 502 Too many connections
```

aborted the **entire file download** and made the repair skip to the next file with **no retry**.

### Root cause

In `downloadWorker` (`internal/repairnzb/repair_nzb.go`), each segment is fetched via `BodyStream` inside a `conc/pool` created `WithCancelOnError()`. Error handling only special-cased `ErrArticleNotFound` (→ queue as broken segment) and `context.Canceled` (→ ignore). **Any other error** logged `"canceling the repair"`, called `cancel()`, and returned — tearing down every in-flight segment for that file.

Two subtleties made this worse:
1. The reported 502 happens at **AUTHINFO PASS time** and surfaces as a *generic wrapped error string*, **not** the `nntppool.ErrServiceUnavailable` sentinel — so any 502-sentinel-only check would miss it.
2. On a mid-request 502, nntppool calls `RemoveProvider` and only re-adds the provider if `ReconnectDelay > 0`. The project never set it, so a provider knocked out by a 502 burst was gone for the rest of the run.

## Changes

- **Retry with backoff** (`repair_nzb.go`): new `retryDownload` wraps per-segment `BodyStream` (and `countMissingParSegments`). Retries transient errors with exponential backoff + full jitter, capped, respecting context cancellation. `isRetryableDownloadErr` retries everything except `context.Canceled`, `ErrArticleNotFound`, and `ErrQuotaExceeded` — so the generic wrapped 502 is retried. Terminal behavior after exhaustion is unchanged (file skipped, run continues).
- **Provider auto-recovery** (`app.go`, `config.go`): wire `ReconnectDelay` (new `reconnect_delay_seconds`, default 30s) so a 502'd provider is re-added automatically.
- **Configurable** (`config.go`, `config.example.yml`): `download_retries` (5), `download_retry_base_delay` (2s), `download_retry_max_delay` (60s). Kept distinct from the existing job-level `max_retries`.

## Behavior after the fix

A 502 now logs `transient error downloading <seg>, retry N/M in <delay>: ...` and waits it out, instead of abandoning the file with `"failed to download file"`.

## Testing

New `internal/repairnzb/retry_test.go` covers: `isRetryableDownloadErr` classification, `backoffDelay` bounds/no-panic, transient-then-success, exhaustion, non-retryable (`ErrArticleNotFound`/`ErrQuotaExceeded`) no-retry, and cancel-during-backoff.

Verified: `go build ./...`, `go vet ./...`, `go test -race ./...`, and `golangci-lint` on changed packages all pass.