### PR TITLE
docs: update GitHub org scope from javi11 to kipsilabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To set up the project for development, follow these steps:
 1. Clone the repository:
 
 ```sh
-git clone https://github.com/javi11/nzb-repair.git
+git clone https://github.com/kipsilabs/nzb-repair.git
 cd nntpcli
 ```
 


### PR DESCRIPTION
## Summary
- Update the clone URL in README to point at the kipsilabs org, matching the repo's actual location.

## Test plan
- [ ] Confirm the clone command works from a clean checkout